### PR TITLE
[REVIEW] skip signals on test and loaddata

### DIFF
--- a/treenode/signals.py
+++ b/treenode/signals.py
@@ -43,14 +43,22 @@ def post_delete_treenode(sender, instance, **kwargs):
 
 
 def connect_signals():
-    post_init.connect(
-        post_init_treenode, dispatch_uid='post_init_treenode')
-    post_migrate.connect(
-        post_migrate_treenode, dispatch_uid='post_migrate_treenode')
-    post_save.connect(
-        post_save_treenode, dispatch_uid='post_save_treenode')
-    post_delete.connect(
-        post_delete_treenode, dispatch_uid='post_delete_treenode')
+    #
+    # Try to handle loaddata and test arguments which dont want these signals
+    #
+    try:
+        action = sys.argv[1]
+    except Exception as e:
+        action = None
+    if action not in ('loaddata', 'test',):
+        post_init.connect(
+            post_init_treenode, dispatch_uid='post_init_treenode')
+        post_migrate.connect(
+            post_migrate_treenode, dispatch_uid='post_migrate_treenode')
+        post_save.connect(
+            post_save_treenode, dispatch_uid='post_save_treenode')
+        post_delete.connect(
+            post_delete_treenode, dispatch_uid='post_delete_treenode')
 
 
 def disconnect_signals():


### PR DESCRIPTION
to stop ancestor errors on loaddata and test

```
  File "/venv/lib/python3.9/site-packages/treenode/models.py", line 435, in __get_node_data
    ancestor_pk = ancestor_obj.get_parent_pk()
AttributeError: Problem installing fixture '/src/mos/apps/mos_app/fixtures/mos_app.json': 'NoneType' object has no attribute 'get_parent_pk'
Sentry is attempting to send 1 pending error messages
```