### PR TITLE
feat: use `__str__` as default fallback for `treenode_display_field`

### DIFF
--- a/tests/models.py
+++ b/tests/models.py
@@ -22,7 +22,6 @@ class Category(TreeNodeModel):
 
 class CategoryUUID(TreeNodeModel):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    treenode_display_field = 'name'
 
     name = models.CharField(max_length=50, unique=True)
 
@@ -30,3 +29,6 @@ class CategoryUUID(TreeNodeModel):
         app_label = 'tests'
         verbose_name = 'Category'
         verbose_name_plural = 'Categories'
+
+    def __str__(self):
+        return f"{self.name}"

--- a/tests/models.py
+++ b/tests/models.py
@@ -22,6 +22,17 @@ class Category(TreeNodeModel):
 
 class CategoryUUID(TreeNodeModel):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    treenode_display_field = 'name'
+
+    name = models.CharField(max_length=50, unique=True)
+
+    class Meta(TreeNodeModel.Meta):
+        app_label = 'tests'
+        verbose_name = 'Category'
+        verbose_name_plural = 'Categories'
+
+
+class CategoryStr(TreeNodeModel):
 
     name = models.CharField(max_length=50, unique=True)
 
@@ -31,4 +42,17 @@ class CategoryUUID(TreeNodeModel):
         verbose_name_plural = 'Categories'
 
     def __str__(self):
-        return f"{self.name}"
+        return f'{self.name}'
+
+class CategoryUUIDStr(TreeNodeModel):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    name = models.CharField(max_length=50, unique=True)
+
+    class Meta(TreeNodeModel.Meta):
+        app_label = 'tests'
+        verbose_name = 'Category'
+        verbose_name_plural = 'Categories'
+
+    def __str__(self):
+        return f'{self.name}'

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,7 +6,7 @@ from django.utils.encoding import force_text
 
 from treenode.cache import clear_cache
 from treenode.utils import join_pks
-from .models import Category, CategoryUUID
+from .models import Category, CategoryStr, CategoryUUID, CategoryUUIDStr
 
 
 class TreeNodeModelsTestCaseBase:
@@ -1224,3 +1224,11 @@ class TreeNodeModelsIdTestCase(TreeNodeModelsTestCaseBase, TransactionTestCase):
 
 class TreeNodeModelsUUIDTestCase(TreeNodeModelsTestCaseBase, TransactionTestCase):
     _category_model = CategoryUUID
+
+
+class TreeNodeModelsIdStrTestCase(TreeNodeModelsTestCaseBase, TransactionTestCase):
+    _category_model = CategoryStr
+
+
+class TreeNodeModelsUUIDStrTestCase(TreeNodeModelsTestCaseBase, TransactionTestCase):
+    _category_model = CategoryUUIDStr

--- a/treenode/models.py
+++ b/treenode/models.py
@@ -215,7 +215,7 @@ class TreeNodeModel(models.Model):
             text = f'{self}'
         else:
             raise ValueError(
-                f'Neither __str__ nor treenode_display_field are defined for model')
+                'Neither __str__ nor treenode_display_field are defined for model')
         text = force_text(text)
         return text
 

--- a/treenode/models.py
+++ b/treenode/models.py
@@ -204,17 +204,18 @@ class TreeNodeModel(models.Model):
     def get_display_text(self):
         """
         Gets the text that will be indented in `get_display` method.
-        Returns the `treenode_display_field` value by default.
+        Returns the `treenode_display_field` value if specified,
+        otherwise falls back on the model's __str__().
         Override this method to return another field or a computed value. #27
         """
         if hasattr(self, 'treenode_display_field') and self.treenode_display_field is not None:
             field_name = getattr(self, 'treenode_display_field', 'pk')
             text = getattr(self, field_name)
         elif type(self).__str__ is not object.__str__:
-            text = f"{self}"
+            text = f'{self}'
         else:
             raise ValueError(
-                f"Neither __str__ nor treenode_display_field are defined for model")
+                f'Neither __str__ nor treenode_display_field are defined for model')
         text = force_text(text)
         return text
 

--- a/treenode/models.py
+++ b/treenode/models.py
@@ -207,8 +207,14 @@ class TreeNodeModel(models.Model):
         Returns the `treenode_display_field` value by default.
         Override this method to return another field or a computed value. #27
         """
-        field_name = getattr(self, 'treenode_display_field', 'pk')
-        text = getattr(self, field_name)
+        if hasattr(self, 'treenode_display_field') and self.treenode_display_field is not None:
+            field_name = getattr(self, 'treenode_display_field', 'pk')
+            text = getattr(self, field_name)
+        elif type(self).__str__ is not object.__str__:
+            text = f"{self}"
+        else:
+            raise ValueError(
+                f"Neither __str__ nor treenode_display_field are defined for model")
         text = force_text(text)
         return text
 


### PR DESCRIPTION
closes #43