### PR TITLE
Clarify order of ancestor queyset

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ obj.get_ancestors_pks()
 obj.ancestors_pks
 ```
 
-Get the **ancestors queryset**:
+Get the **ancestors queryset** (ordered from parent to root):
 ```python
 obj.get_ancestors_queryset()
 ```


### PR DESCRIPTION
The `list` function and the `queryset` functions actually return the inverse order of ancestors from one another, tripped me up a bit.