### PR TITLE
Use specific database for write operations in multi-DB setup

### DIFF
--- a/treenode/models.py
+++ b/treenode/models.py
@@ -1,7 +1,7 @@
 import uuid
 
 from django.core.validators import MaxValueValidator, MinValueValidator
-from django.db import models, transaction, router
+from django.db import models, router, transaction
 from django.utils.encoding import force_str
 from django.utils.html import conditional_escape
 from django.utils.text import slugify

--- a/treenode/models.py
+++ b/treenode/models.py
@@ -1,7 +1,7 @@
 import uuid
 
 from django.core.validators import MaxValueValidator, MinValueValidator
-from django.db import models, transaction
+from django.db import models, transaction, router
 from django.utils.encoding import force_str
 from django.utils.html import conditional_escape
 from django.utils.text import slugify
@@ -147,7 +147,7 @@ class TreeNodeModel(models.Model):
     @classmethod
     def delete_tree(cls):
         with no_signals():
-            with transaction.atomic():
+            with transaction.atomic(using=router.db_for_write(TreeNodeModel)):
                 cls.objects.all().delete()
             clear_refs(cls)
             clear_cache(cls)
@@ -424,7 +424,7 @@ class TreeNodeModel(models.Model):
             # update db
             objs_data = cls.__get_nodes_data()
 
-            with transaction.atomic():
+            with transaction.atomic(using=router.db_for_write(TreeNodeModel)):
                 obj_manager = cls.objects
                 for obj_pk, obj_data in objs_data.items():
                     obj_manager.filter(pk=obj_pk).update(**obj_data)


### PR DESCRIPTION
---
name: Pull request
about: Submit a pull request for this project
assignees: fabiocaccamo

---

**Related issue**
Database Configuration error in update_tree #123

**Checklist before requesting a review**
- [X] I have performed a self-review of my code.
- [NA] I have added tests for the proposed changes.
- [NA] I have run the tests and there are not errors.

**Summary:**

This PR introduces modifications to enhance support for write operations in environments utilizing multiple databases. The modifications ensure that the `update_tree` and `delete_tree` methods in the `models.py` file direct their write operations to the correct database as specified by the database router's `db_for_write` method.

**Changes Made:**

1. **`update_tree` Method:**
   - The method has been modified to use the database specified for write operations by the database router.
   - The `using` argument in `transaction.atomic()` is employed as `transaction.atomic(using=router.db_for_write(TreeNodeModel))`.

2. **`delete_tree` Method:**
   - The method has been similarly modified to ensure correct routing of write operations to the appropriate database.

**Rationale:**

In projects utilizing multiple databases, it is essential to direct write operations to the appropriate database reliably. The modifications in this PR address this need by explicitly specifying the database for write operations in `update_tree` and `delete_tree` methods, contributing to the overall stability and reliability of the package in multi-database environments.


**Regarding Testing**
Wanted to throw in some tests for these changes, but that would need a bit of a setup overhaul to simulate multiple databases – seemed a bit overkill for this PR.

Did run manual checks to ensure everything’s in order. I believe the changes shouldn’t mess with the library’s flow and should be a plus for those juggling multiple databases.
