### PR TITLE
Increase `tn_priority` max value to `9999999999`

### DIFF
--- a/treenode/models.py
+++ b/treenode/models.py
@@ -112,7 +112,7 @@ class TreeNodeModel(models.Model):
 
     tn_priority = models.PositiveIntegerField(
         default=0,
-        validators=[MinValueValidator(0), MaxValueValidator(9999)],
+        validators=[MinValueValidator(0), MaxValueValidator(9999999999)],
         verbose_name=_("Priority"),
     )
 


### PR DESCRIPTION
**Describe your changes**
I want to use the current timestamp (epoch) to sort the tree nodes by creation date, e.g., `1726814949`. Although `priority_max = 9999999999` in `__get_node_order_str`:

https://github.com/fabiocaccamo/django-treenode/blob/5663c5b47ae0006a131bd054ed8e590586f801d8/treenode/models.py#L461-L468

the maximum value of the `tn_priority` field is set to `MaxValueValidator(9999)`:

https://github.com/fabiocaccamo/django-treenode/blob/5663c5b47ae0006a131bd054ed8e590586f801d8/treenode/models.py#L113-L117

My current workaround is to overwrite the `tn_priority` field in my own model:

```python
class MyModel(TreeNodeModel):
    ...
    tn_priority = models.PositiveIntegerField(
        default=0,
        validators=[MinValueValidator(0), MaxValueValidator(9999999999)],
        verbose_name=_("Priority"),
    )
```

This pull request increases the maximum value for `tn_priority` to `9999999999`, enabling the use of timestamps for sorting and aligning it with the `priority_max` value in `__get_node_order_str`.

**Checklist before requesting a review**
- [x] I have performed a self-review of my code.
- [ ] I have added tests for the proposed changes.
- [ ] I have run the tests and there are not errors.
