### PR TITLE
Fix call to update_tree upon migration to zero causes ProgrammingErro…

### DIFF
--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,34 @@
+from contextlib import contextmanager
+from django.apps import apps
+from django.core.management.sql import emit_post_migrate_signal
+from django.db import connection, OperationalError, ProgrammingError
+from django.test import TestCase
+
+from tests.models import Category
+
+ModelToBeDestroyed = Category
+
+class TreeNodeDropTableTestCase(TestCase):
+    @contextmanager
+    def assertNotRaises(self, exc_type):
+        try:
+            yield None
+        except exc_type as e:
+            raise self.failureException('{} raised'.format(e))
+
+    def test_destroy_model(self):
+        table_name = ModelToBeDestroyed._meta.db_table
+        app_label = ModelToBeDestroyed._meta.app_label
+        app_config = apps.get_app_config(app_label)
+
+        # Drop the table (as if by a `migrate app zero`)
+        with connection.cursor() as cursor:
+            cursor.execute(f'DROP TABLE {table_name}')
+
+        # Try to use the model - this should raise an error
+        with self.assertRaises((OperationalError, ProgrammingError)):
+            list(ModelToBeDestroyed.objects.all())
+
+        # Emit a post_migrate signal as done after migration to zero
+        with self.assertNotRaises(OperationalError):
+            emit_post_migrate_signal(verbosity=1, interactive=False, db=connection.alias)

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,12 +1,14 @@
 from contextlib import contextmanager
+
 from django.apps import apps
 from django.core.management.sql import emit_post_migrate_signal
-from django.db import connection, OperationalError, ProgrammingError
+from django.db import OperationalError, ProgrammingError, connection
 from django.test import TestCase
 
 from tests.models import Category
 
 ModelToBeDestroyed = Category
+
 
 class TreeNodeDropTableTestCase(TestCase):
     @contextmanager
@@ -14,7 +16,7 @@ class TreeNodeDropTableTestCase(TestCase):
         try:
             yield None
         except exc_type as e:
-            raise self.failureException('{} raised'.format(e))
+            raise self.failureException(f"{e} raised")
 
     def test_destroy_model(self):
         table_name = ModelToBeDestroyed._meta.db_table
@@ -23,7 +25,7 @@ class TreeNodeDropTableTestCase(TestCase):
 
         # Drop the table (as if by a `migrate app zero`)
         with connection.cursor() as cursor:
-            cursor.execute(f'DROP TABLE {table_name}')
+            cursor.execute(f"DROP TABLE {table_name}")
 
         # Try to use the model - this should raise an error
         with self.assertRaises((OperationalError, ProgrammingError)):
@@ -31,4 +33,6 @@ class TreeNodeDropTableTestCase(TestCase):
 
         # Emit a post_migrate signal as done after migration to zero
         with self.assertNotRaises(OperationalError):
-            emit_post_migrate_signal(verbosity=1, interactive=False, db=connection.alias)
+            emit_post_migrate_signal(
+                verbosity=1, interactive=False, db=connection.alias
+            )

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -2,25 +2,23 @@ from contextlib import contextmanager
 
 from django.core.management.sql import emit_post_migrate_signal
 from django.db import OperationalError, ProgrammingError, connection
-from django.test import TestCase
+from django.test import TransactionTestCase
 
 from tests.models import Category
 
 ModelToBeDestroyed = Category
 
 
-class TreeNodeDropTableTestCase(TestCase):
+class TreeNodeDropTableTestCase(TransactionTestCase):
     @contextmanager
     def assertNotRaises(self, exc_type):
         try:
             yield None
-        except exc_type as e:
-            raise self.failureException(f"{e} raised") from e
+        except exc_type as error:
+            raise self.failureException(f"{error} raised") from error
 
     def test_destroy_model(self):
         table_name = ModelToBeDestroyed._meta.db_table
-        # app_label = ModelToBeDestroyed._meta.app_label
-        # app_config = apps.get_app_config(app_label)
 
         # drop the table (as if by a `migrate app zero`)
         with connection.cursor() as cursor:
@@ -29,9 +27,6 @@ class TreeNodeDropTableTestCase(TestCase):
         # try to use the model - this should raise an error
         with self.assertRaises((OperationalError, ProgrammingError)):
             list(ModelToBeDestroyed.objects.all())
-
-        # clear the failed transaction state before emitting post_migrate
-        connection.rollback()
 
         # emit a post_migrate signal as done after migration to zero
         with self.assertNotRaises((OperationalError, ProgrammingError)):

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,6 +1,5 @@
 from contextlib import contextmanager
 
-from django.apps import apps
 from django.core.management.sql import emit_post_migrate_signal
 from django.db import OperationalError, ProgrammingError, connection
 from django.test import TestCase
@@ -16,23 +15,25 @@ class TreeNodeDropTableTestCase(TestCase):
         try:
             yield None
         except exc_type as e:
-            raise self.failureException(f"{e} raised")
+            raise self.failureException(f"{e} raised") from e
 
     def test_destroy_model(self):
         table_name = ModelToBeDestroyed._meta.db_table
-        app_label = ModelToBeDestroyed._meta.app_label
-        app_config = apps.get_app_config(app_label)
+        # app_label = ModelToBeDestroyed._meta.app_label
+        # app_config = apps.get_app_config(app_label)
 
-        # Drop the table (as if by a `migrate app zero`)
+        # drop the table (as if by a `migrate app zero`)
         with connection.cursor() as cursor:
             cursor.execute(f"DROP TABLE {table_name}")
 
-        # Try to use the model - this should raise an error
+        # try to use the model - this should raise an error
         with self.assertRaises((OperationalError, ProgrammingError)):
             list(ModelToBeDestroyed.objects.all())
 
-        # Emit a post_migrate signal as done after migration to zero
+        # emit a post_migrate signal as done after migration to zero
         with self.assertNotRaises(OperationalError):
             emit_post_migrate_signal(
-                verbosity=1, interactive=False, db=connection.alias
+                verbosity=1,
+                interactive=False,
+                db=connection.alias,
             )

--- a/treenode/signals.py
+++ b/treenode/signals.py
@@ -30,10 +30,9 @@ def post_init_treenode(sender, instance, **kwargs):
 
 def post_migrate_treenode(sender, **kwargs):
     for sender_model in sender.get_models():
-        if __is_treenode_model(sender_model) and \
-             __table_exists(
-                 table_name=sender_model._meta.db_table,
-                 connection_name=kwargs['using']):
+        if __is_treenode_model(sender_model) and __table_exists(
+            table_name=sender_model._meta.db_table, connection_name=kwargs["using"]
+        ):
             sender_model.update_tree()
 
 


### PR DESCRIPTION
…r. #188

---
name: Pull request
about: Submit a pull request for this project
assignees: fabiocaccamo

---

**Describe your changes**
I added a table exists check to post_migrate_treenode signal handler so that it won't call update_tree if the table is not there.

**Related issue**
#188

**Checklist before requesting a review**
- [x] I have performed a self-review of my code.
- [x] I have added tests for the proposed changes.
- [x] I have run the tests and there are no errors.
