### PR TITLE
Add circular reference detection to prevent infinite recursion

### DIFF
--- a/treenode/models.py
+++ b/treenode/models.py
@@ -526,6 +526,9 @@ class TreeNodeModel(models.Model):
 
     @classmethod
     def __get_nodes_data(cls):  # noqa: C901
+        if cls.objects.filter(pk=models.F('tn_parent_id')).exists():
+            raise ValueError("Circular reference detected.")
+
         objs_qs = cls.objects.select_related("tn_parent")
         objs_list = list(objs_qs)
         objs_dict = {str(obj.pk): obj for obj in objs_list}


### PR DESCRIPTION
---
name: Pull request
about: Prevent infinite loops by detecting self-referencing nodes
assignees: fabiocaccamo
---

**Describe your changes**
Added circular reference detection to prevent infinite recursion when a node references itself as its parent. The validation is implemented in the `__get_nodes_data` method and checks for cases where `pk == tn_parent_id`. When a circular reference is detected, a clear `ValueError` is raised with the message "Circular reference detected."

**Related issue**
N/A (proactive improvement to prevent a common issue that can cause infinite recursion)

**Checklist before requesting a review**
- [x] I have performed a self-review of my code.
- [ ] I have added tests for the proposed changes.
- [x] I have run the tests and there are not errors.